### PR TITLE
Normalize the padding

### DIFF
--- a/src/scripts/chartist-plugin-axistitle.js
+++ b/src/scripts/chartist-plugin-axistitle.js
@@ -56,17 +56,18 @@
                     );
                 }
 
-                var xPos;
-                var yPos;
-                var title;
+                var xPos,
+                    yPos,
+                    title,
+                    chartPadding = Chartist.normalizePadding(data.options.chartPadding); // normalize the padding in case the full padding object was not passed into the options
 
                 //position axis X title
                 if (options.axisX.axisTitle && data.axisX) {
 
                     xPos = (data.axisX.axisLength / 2) + data.options.axisY.offset +
-                        data.options.chartPadding.left;
+                        chartPadding.left;
 
-                    yPos = data.options.chartPadding.top;
+                    yPos = chartPadding.top;
 
                     if (data.options.axisY.position === 'end') {
                         xPos -= data.options.axisY.offset;
@@ -94,7 +95,7 @@
                     xPos = 0;
 
 
-                    yPos = (data.axisY.axisLength / 2) + data.options.chartPadding
+                    yPos = (data.axisY.axisLength / 2) + chartPadding
                             .top;
 
                     if (data.options.axisX.position === 'start') {


### PR DESCRIPTION
This changeset normalizes the chart padding before trying to access the object's properties since it is possible to pass in an integer and not an object as the padding option. Fixes #18 