### PR TITLE
Remove dependency on window and document

### DIFF
--- a/src/scripts/chartist-plugin-axistitle.js
+++ b/src/scripts/chartist-plugin-axistitle.js
@@ -4,7 +4,7 @@
  * author: alex stanbury
  */
 /* global Chartist */
-(function (window, document, Chartist) {
+(function (Chartist) {
     'use strict';
 
     var axisDefaults = {
@@ -123,4 +123,4 @@
             });
         };
     };
-}(window, document, Chartist));
+}(Chartist));


### PR DESCRIPTION
I'm using this plugin in a React project and the server side rendering failed repeatedly because the plugin
requests the `window` and `document` variables.

Looking at the code, I saw that these variables were not used at all. I therefore removed them, which solved my issue with SSR.

I tried to update the dist folder but the diff got quite large (also updating the license for example). Do you want me to update it nonetheless?